### PR TITLE
fix(dep): input handling issues on macOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ exclude = ["/examples", "/webview-dist", "/webview-src", "/node_modules"]
 links = "tauri-plugin-appload"
 
 [dependencies]
-tauri = { version = "2.0.6", features = ["unstable"] }
+tauri = { version = "2.0.6" }
 serde = "1.0"
 serde_json = { version = "1", features = [] }
 thiserror = { version = "2.0.3", features = [] }


### PR DESCRIPTION
The unstable flag was causing arrow keys to
display ANSI escape sequences as literal text
instead of performing cursor navigation

For example the arrow keys in URL input fields
display escape sequences (`^[[C, ^[[D, ^[[A, ^[[B`) as literal text.

The unstable feature flag was originally added to
support experimental features that were required
for functionality that is no longer needed
in the current implementation.

See:
- [Tauri Issue #9257] - Keyboard shortcuts broken with unstable flag
- [Tauri Issue #10194] - Arrow keys printing invalid characters
- [Wry Issue #1177] - Related macOS input handling issues